### PR TITLE
Fix: Correct sponsor text selector to bypass adbot

### DIFF
--- a/src/components/animations/sponsors/SponsorPool.astro
+++ b/src/components/animations/sponsors/SponsorPool.astro
@@ -24,7 +24,7 @@ import { Sparkles } from "@/lib/icon-library";
   </div>
 
   <div
-    class="sponsor-text absolute left-1/2 top-[5rem] z-20 flex h-32 w-fit -translate-x-1/2 scale-[0.85] flex-col items-center justify-center gap-5"
+    class="become-text absolute left-1/2 top-[5rem] z-20 flex h-32 w-fit -translate-x-1/2 scale-[0.85] flex-col items-center justify-center gap-5"
   >
     <p class="heading-font text-nowrap text-3xl text-white md:text-6xl">
       {sponsorConfig.sponsorText.text}

--- a/src/components/sections/Sponsors.astro
+++ b/src/components/sections/Sponsors.astro
@@ -96,7 +96,7 @@ const { className, id } = Astro.props;
         1.3,
       )
       .fromTo(
-        ".sponsor-text",
+        ".become-text",
         { opacity: 0, scale: 0.85, y: 20 },
         { opacity: 1, scale: 1, y: 0, duration: 0.8, ease: "back.out(1.7)" },
         1.3,


### PR DESCRIPTION
This commit changes the selector for the sponsor text from ".sponsor-text" to ".become-text" in order to prevent ad blockers from interfering with the
animation.  This fixes an issue where the sponsor
text was not being displayed correctly.

(sponsor-img-allingment-sohel)